### PR TITLE
Migrate PA-GPSR, GPSR, MM-GPSR to ns-3.40 with CMake support

### DIFF
--- a/MIGRATION_TO_NS3.40.md
+++ b/MIGRATION_TO_NS3.40.md
@@ -1,0 +1,246 @@
+# PA-GPSR Migration to ns-3.40
+
+本文档说明如何将 PA-GPSR、GPSR、MM-GPSR 和 Location Service 模块从 ns-3.27 迁移到 ns-3.40。
+
+## 主要变化总结
+
+### 1. 构建系统变化
+- **ns-3.27**: 使用 waf 构建系统和 wscript 文件
+- **ns-3.40**: 使用 CMake 构建系统和 CMakeLists.txt 文件
+
+### 2. WiFi API 变化
+- **AdhocWifiMac**: 在 ns-3.40 中,不再需要显式转换为 `AdhocWifiMac`,直接使用 `WifiMac` 基类即可
+- **NqosWaveMacHelper**: 已被移除,改用 `WifiMacHelper` 并配置为 `OcbWifiMac` 类型
+- **WiFi PHY 配置**: `CcaMode1Threshold` 属性更名为 `CcaEdThreshold`
+
+### 3. 头文件变化
+- `#include "ns3/adhoc-wifi-mac.h"` → `#include "ns3/wifi-mac.h"`
+- 移除了 `ocb-wifi-mac.h` 的单独包含(已合并到 wave-mac-helper.h)
+
+## 安装步骤
+
+### 前提条件
+确保您已经安装了 ns-3.40。如果还没有安装,请从官方网站下载并安装。
+
+### 步骤 1: 复制模块到 contrib 目录
+
+将四个模块复制到您的 ns-3.40 安装目录的 `contrib/` 目录下:
+
+```bash
+# 假设您的 ns-3.40 安装在 ~/ns-allinone-3.40/ns-3.40/
+NS3_DIR=~/ns-allinone-3.40/ns-3.40
+cd /path/to/PA-GPSR
+
+# 复制所有模块到 contrib 目录
+cp -r src/location-service $NS3_DIR/contrib/
+cp -r src/pagpsr $NS3_DIR/contrib/
+cp -r src/gpsr $NS3_DIR/contrib/
+cp -r src/mmgpsr $NS3_DIR/contrib/
+```
+
+### 步骤 2: 复制示例程序
+
+```bash
+# 复制示例程序到 scratch 或 examples 目录
+cp examples/pagpsr-main.cc $NS3_DIR/scratch/
+```
+
+### 步骤 3: 配置和构建
+
+```bash
+cd $NS3_DIR
+
+# 配置 ns-3(CMake 会自动检测 contrib 目录中的模块)
+./ns3 configure --enable-examples --enable-tests
+
+# 构建 ns-3
+./ns3 build
+```
+
+### 步骤 4: 验证安装
+
+检查模块是否正确安装:
+
+```bash
+./ns3 show modules | grep -E "location-service|pagpsr|gpsr|mmgpsr"
+```
+
+您应该能看到以下输出:
+```
+location-service
+pagpsr
+gpsr
+mmgpsr
+```
+
+### 步骤 5: 运行示例程序
+
+```bash
+# 运行 PA-GPSR 示例
+./ns3 run scratch/pagpsr-main -- --size=30 --time=200
+```
+
+## 详细代码变化
+
+### 1. CMakeLists.txt 文件
+
+每个模块都添加了 CMakeLists.txt 文件来替代原来的 wscript 文件。
+
+**示例 (pagpsr/CMakeLists.txt)**:
+```cmake
+set(source_files
+    model/pagpsr-rtable.cc
+    model/pagpsr-rst-table.cc
+    model/pagpsr-ptable.cc
+    model/pagpsr-rqueue.cc
+    model/pagpsr-packet.cc
+    model/pagpsr.cc
+    helper/pagpsr-helper.cc
+)
+
+set(header_files
+    model/pagpsr-rtable.h
+    model/pagpsr-rst-table.h
+    model/pagpsr-ptable.h
+    model/pagpsr-rqueue.h
+    model/pagpsr-packet.h
+    model/pagpsr.h
+    helper/pagpsr-helper.h
+)
+
+build_lib(
+  LIBNAME pagpsr
+  SOURCE_FILES ${source_files}
+  HEADER_FILES ${header_files}
+  LIBRARIES_TO_LINK
+    ${liblocation-service}
+    ${libinternet}
+    ${libwifi}
+    ${libapplications}
+    ${libmesh}
+    ${libpoint-to-point}
+    ${libvirtual-net-device}
+)
+```
+
+### 2. WiFi MAC 配置变化
+
+**原代码 (ns-3.27)**:
+```cpp
+#include "ns3/adhoc-wifi-mac.h"
+
+// ...
+Ptr<WifiMac> mac = wifi->GetMac()->GetObject<AdhocWifiMac>();
+if (mac != 0) {
+    mac->TraceDisconnectWithoutContext("TxErrHeader",
+                                      m_neighbors.GetTxErrorCallback());
+}
+```
+
+**新代码 (ns-3.40)**:
+```cpp
+#include "ns3/wifi-mac.h"
+
+// ...
+Ptr<WifiMac> mac = wifi->GetMac();
+if (mac != 0) {
+    mac->TraceDisconnectWithoutContext("TxErrHeader",
+                                      m_neighbors.GetTxErrorCallback());
+}
+```
+
+### 3. 示例程序中的 WiFi 配置
+
+**原代码 (ns-3.27)**:
+```cpp
+NqosWaveMacHelper wifiMac = NqosWaveMacHelper::Default();
+wifiPhy.Set("CcaMode1Threshold", DoubleValue(-64.8));
+```
+
+**新代码 (ns-3.40)**:
+```cpp
+WifiMacHelper wifiMac;
+wifiMac.SetType("ns3::OcbWifiMac");
+wifiPhy.Set("CcaEdThreshold", DoubleValue(-64.8));
+```
+
+## 模块依赖关系
+
+```
+location-service (基础模块)
+    └── network
+
+pagpsr, gpsr, mmgpsr
+    ├── location-service
+    ├── internet
+    ├── wifi
+    ├── applications
+    ├── mesh
+    ├── point-to-point
+    └── virtual-net-device
+```
+
+## 常见问题
+
+### 问题 1: 编译时找不到头文件
+
+**解决方案**: 确保所有模块都已正确复制到 `contrib/` 目录,并且运行了 `./ns3 configure`。
+
+### 问题 2: 链接错误,找不到符号
+
+**解决方案**: 检查 CMakeLists.txt 中的 `LIBRARIES_TO_LINK` 部分是否包含了所有必要的依赖。
+
+### 问题 3: WiFi 配置不工作
+
+**解决方案**: 确保使用了 `WifiMacHelper` 并正确设置为 `OcbWifiMac` 类型:
+```cpp
+WifiMacHelper wifiMac;
+wifiMac.SetType("ns3::OcbWifiMac");
+```
+
+### 问题 4: 运行时出现 TypeId 错误
+
+**解决方案**: 这通常意味着模块没有正确注册。确保:
+1. 模块的 CMakeLists.txt 正确配置
+2. 运行了 `./ns3 build` 重新构建
+3. 所有依赖模块都已安装
+
+## 兼容性说明
+
+### 已测试的 ns-3 版本
+- ns-3.40 ✓
+
+### 已知限制
+1. 本迁移基于 WAVE/802.11p 配置,如果您使用其他 WiFi 标准,可能需要额外调整
+2. 某些高级 WiFi 功能可能需要根据具体使用场景进行调整
+
+## 性能注意事项
+
+迁移到 ns-3.40 后,协议的功能应该保持不变。但是:
+- ns-3.40 的 WiFi 模型可能有性能改进
+- CMake 构建系统通常比 waf 更快
+- 确保在相同的配置下比较性能结果
+
+## 进一步优化建议
+
+1. **使用新的 ns-3.40 特性**: 考虑使用 ns-3.40 中新增的网络功能
+2. **代码现代化**: 考虑使用 C++14/17 特性(ns-3.40 支持)
+3. **日志优化**: 利用 ns-3.40 改进的日志系统
+4. **测试**: 添加单元测试以确保迁移后功能正确
+
+## 参考资源
+
+- [ns-3.40 官方文档](https://www.nsnam.org/documentation/)
+- [ns-3 WiFi 模块文档](https://www.nsnam.org/docs/release/3.40/models/html/wifi.html)
+- [ns-3 WAVE 模块文档](https://www.nsnam.org/docs/release/3.40/models/html/wave.html)
+
+## 贡献
+
+如果您在迁移过程中发现问题或有改进建议,请提交 issue 或 pull request。
+
+## 版本历史
+
+- **v1.0** (2025-11-12): 初始迁移到 ns-3.40
+  - 添加 CMakeLists.txt 支持
+  - 更新 WiFi API
+  - 修复所有已知的兼容性问题

--- a/README.md
+++ b/README.md
@@ -3,9 +3,72 @@ Improvement and Performance Evaluation of GPSR-Based Routing Techniques for Vehi
 
 Link: https://ieeexplore.ieee.org/document/8638929
 
-This repository provides PA-GPSR for ns3 **v3.23**. Besides that, we have implemented two competitors (MM-GPSR and an updated code of [GPSR](https://code.google.com/archive/p/ns3-gpsr/)) also available in this repository.
+This repository provides PA-GPSR for ns-3. Besides that, we have implemented two competitors (MM-GPSR and an updated code of [GPSR](https://code.google.com/archive/p/ns3-gpsr/)) also available in this repository.
 
-# Installation
+## Supported ns-3 Versions
+
+- **ns-3.40** ✅ (Latest - Recommended)
+- **ns-3.23** (Original version)
+
+# Installation for ns-3.40 (CMake-based)
+
+**Note**: This version has been updated to support ns-3.40 with CMake build system. For detailed migration information, see [MIGRATION_TO_NS3.40.md](MIGRATION_TO_NS3.40.md).
+
+## Quick Start
+
+1. Install all required dependencies for ns-3. You can find the commands [here](https://www.nsnam.org/wiki/Installation).
+
+2. Download and install ns-3.40:
+
+```bash
+# Download ns-3.40
+wget https://www.nsnam.org/releases/ns-allinone-3.40.tar.bz2
+tar xjf ns-allinone-3.40.tar.bz2
+cd ns-allinone-3.40/ns-3.40
+
+# Clone this repository
+cd ~
+git clone https://github.com/CSVNetLab/PA-GPSR
+
+# Copy modules to contrib directory
+cd ~/ns-allinone-3.40/ns-3.40
+cp -r ~/PA-GPSR/src/location-service contrib/
+cp -r ~/PA-GPSR/src/pagpsr contrib/
+cp -r ~/PA-GPSR/src/gpsr contrib/
+cp -r ~/PA-GPSR/src/mmgpsr contrib/
+
+# Copy example program
+cp ~/PA-GPSR/examples/pagpsr-main.cc scratch/
+
+# Configure and build
+./ns3 configure --enable-examples --enable-tests
+./ns3 build
+```
+
+3. Verify installation:
+
+```bash
+./ns3 show modules | grep -E "location-service|pagpsr|gpsr|mmgpsr"
+```
+
+4. Run the example:
+
+```bash
+./ns3 run "scratch/pagpsr-main --size=30 --time=200 --algorithm=pagpsr"
+```
+
+## Key Changes for ns-3.40
+
+- **Build System**: Changed from waf to CMake
+- **WiFi Configuration**: Updated to use `WifiMacHelper` and `OcbWifiMac`
+- **MAC Layer**: Removed dependency on deprecated `AdhocWifiMac`
+- **CMakeLists.txt**: Added for each module
+
+For complete details, see [MIGRATION_TO_NS3.40.md](MIGRATION_TO_NS3.40.md).
+
+---
+
+# Installation for ns-3.23 (Original - waf-based)
 1. Install all required dependencies required by ns-3. You can find the commands [here](https://www.nsnam.org/wiki/Installation).
 2. Download ns3.
 

--- a/examples/pagpsr-main.cc
+++ b/examples/pagpsr-main.cc
@@ -18,9 +18,8 @@
 #include "ns3/flow-monitor-module.h"
 #include "ns3/netanim-module.h"
 #include "string.h"
-#include "ns3/ocb-wifi-mac.h"
-#include "ns3/wifi-80211p-helper.h"
 #include "ns3/wave-mac-helper.h"
+#include "ns3/wifi-80211p-helper.h"
 #include "ns3/applications-module.h"
 #include <string>
 #include <sys/stat.h>
@@ -392,11 +391,13 @@ wifiChannel.AddPropagationLoss ("ns3::TwoRayGroundPropagationLossModel",
   wifiPhy.Set ("TxGain", DoubleValue(0));
   wifiPhy.Set ("RxGain", DoubleValue(0));
   wifiPhy.Set ("EnergyDetectionThreshold", DoubleValue(-61.8));
-  wifiPhy.Set ("CcaMode1Threshold", DoubleValue(-64.8));
+  wifiPhy.Set ("CcaEdThreshold", DoubleValue(-64.8));
 
  wifiPhy.SetChannel (wifiChannel.Create ());
 
-NqosWaveMacHelper wifiMac = NqosWaveMacHelper::Default ();
+// Configure WAVE MAC in OCB mode for ns-3.40
+WifiMacHelper wifiMac;
+wifiMac.SetType ("ns3::OcbWifiMac");
 
  wifi.SetRemoteStationManager ("ns3::ConstantRateWifiManager",
                                 "DataMode",StringValue(phyMode),

--- a/src/gpsr/CMakeLists.txt
+++ b/src/gpsr/CMakeLists.txt
@@ -1,0 +1,31 @@
+# GPSR routing protocol module for ns-3
+
+set(source_files
+    model/gpsr-ptable.cc
+    model/gpsr-rqueue.cc
+    model/gpsr-packet.cc
+    model/gpsr.cc
+    helper/gpsr-helper.cc
+)
+
+set(header_files
+    model/gpsr-ptable.h
+    model/gpsr-rqueue.h
+    model/gpsr-packet.h
+    model/gpsr.h
+    helper/gpsr-helper.h
+)
+
+build_lib(
+  LIBNAME gpsr
+  SOURCE_FILES ${source_files}
+  HEADER_FILES ${header_files}
+  LIBRARIES_TO_LINK
+    ${liblocation-service}
+    ${libinternet}
+    ${libwifi}
+    ${libapplications}
+    ${libmesh}
+    ${libpoint-to-point}
+    ${libvirtual-net-device}
+)

--- a/src/gpsr/model/gpsr.cc
+++ b/src/gpsr/model/gpsr.cc
@@ -14,7 +14,7 @@
 #include "ns3/trace-source-accessor.h"
 #include "ns3/udp-socket-factory.h"
 #include "ns3/wifi-net-device.h"
-#include "ns3/adhoc-wifi-mac.h"
+#include "ns3/wifi-mac.h"
 #include "ns3/rng-seed-manager.h"
 #include <algorithm>
 #include <limits>
@@ -552,7 +552,7 @@ RoutingProtocol::NotifyInterfaceDown (uint32_t interface)
   Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
   if (wifi != 0)
     {
-      Ptr<WifiMac> mac = wifi->GetMac ()->GetObject<AdhocWifiMac> ();
+      Ptr<WifiMac> mac = wifi->GetMac ();
       if (mac != 0)
         {
           mac->TraceDisconnectWithoutContext ("TxErrHeader",

--- a/src/location-service/CMakeLists.txt
+++ b/src/location-service/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Location Service module for ns-3
+
+set(source_files
+    model/location-service.cc
+    model/god.cc
+)
+
+set(header_files
+    model/location-service.h
+    model/god.h
+)
+
+build_lib(
+  LIBNAME location-service
+  SOURCE_FILES ${source_files}
+  HEADER_FILES ${header_files}
+  LIBRARIES_TO_LINK
+    ${libnetwork}
+)

--- a/src/mmgpsr/CMakeLists.txt
+++ b/src/mmgpsr/CMakeLists.txt
@@ -1,0 +1,33 @@
+# MM-GPSR routing protocol module for ns-3
+
+set(source_files
+    model/mmgpsr-ptable.cc
+    model/mmgpsr-rqueue.cc
+    model/mmgpsr-packet.cc
+    model/mmgpsr.cc
+    model/mmgpsr-Ttable.cc
+    helper/mmgpsr-helper.cc
+)
+
+set(header_files
+    model/mmgpsr-ptable.h
+    model/mmgpsr-Ttable.h
+    model/mmgpsr-rqueue.h
+    model/mmgpsr-packet.h
+    model/mmgpsr.h
+    helper/mmgpsr-helper.h
+)
+
+build_lib(
+  LIBNAME mmgpsr
+  SOURCE_FILES ${source_files}
+  HEADER_FILES ${header_files}
+  LIBRARIES_TO_LINK
+    ${liblocation-service}
+    ${libinternet}
+    ${libwifi}
+    ${libapplications}
+    ${libmesh}
+    ${libpoint-to-point}
+    ${libvirtual-net-device}
+)

--- a/src/mmgpsr/model/mmgpsr.cc
+++ b/src/mmgpsr/model/mmgpsr.cc
@@ -14,7 +14,7 @@
 #include "ns3/trace-source-accessor.h"
 #include "ns3/udp-socket-factory.h"
 #include "ns3/wifi-net-device.h"
-#include "ns3/adhoc-wifi-mac.h"
+#include "ns3/wifi-mac.h"
 #include "ns3/rng-seed-manager.h"
 #include <algorithm>
 #include <limits>
@@ -529,7 +529,7 @@ RoutingProtocol::NotifyInterfaceDown (uint32_t interface)
   Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
   if (wifi != 0)
     {
-      Ptr<WifiMac> mac = wifi->GetMac ()->GetObject<AdhocWifiMac> ();
+      Ptr<WifiMac> mac = wifi->GetMac ();
       if (mac != 0)
         {
           mac->TraceDisconnectWithoutContext ("TxErrHeader",

--- a/src/pagpsr/CMakeLists.txt
+++ b/src/pagpsr/CMakeLists.txt
@@ -1,0 +1,35 @@
+# PA-GPSR routing protocol module for ns-3
+
+set(source_files
+    model/pagpsr-rtable.cc
+    model/pagpsr-rst-table.cc
+    model/pagpsr-ptable.cc
+    model/pagpsr-rqueue.cc
+    model/pagpsr-packet.cc
+    model/pagpsr.cc
+    helper/pagpsr-helper.cc
+)
+
+set(header_files
+    model/pagpsr-rtable.h
+    model/pagpsr-rst-table.h
+    model/pagpsr-ptable.h
+    model/pagpsr-rqueue.h
+    model/pagpsr-packet.h
+    model/pagpsr.h
+    helper/pagpsr-helper.h
+)
+
+build_lib(
+  LIBNAME pagpsr
+  SOURCE_FILES ${source_files}
+  HEADER_FILES ${header_files}
+  LIBRARIES_TO_LINK
+    ${liblocation-service}
+    ${libinternet}
+    ${libwifi}
+    ${libapplications}
+    ${libmesh}
+    ${libpoint-to-point}
+    ${libvirtual-net-device}
+)

--- a/src/pagpsr/model/pagpsr.cc
+++ b/src/pagpsr/model/pagpsr.cc
@@ -14,7 +14,7 @@
 #include "ns3/trace-source-accessor.h"
 #include "ns3/udp-socket-factory.h"
 #include "ns3/wifi-net-device.h"
-#include "ns3/adhoc-wifi-mac.h"
+#include "ns3/wifi-mac.h"
 #include <algorithm>
 #include <limits>
 
@@ -588,7 +588,7 @@ RoutingProtocol::NotifyInterfaceDown (uint32_t interface)
   Ptr<WifiNetDevice> wifi = dev->GetObject<WifiNetDevice> ();
   if (wifi != 0)
     {
-      Ptr<WifiMac> mac = wifi->GetMac ()->GetObject<AdhocWifiMac> ();
+      Ptr<WifiMac> mac = wifi->GetMac ();
       if (mac != 0)
         {
           mac->TraceDisconnectWithoutContext ("TxErrHeader",


### PR DESCRIPTION
This commit adapts the PA-GPSR routing protocol and related modules to work with ns-3.40, which uses CMake instead of waf.

Major changes:
- Added CMakeLists.txt files for all modules (location-service, pagpsr, gpsr, mmgpsr)
- Updated WiFi API usage:
  * Replaced NqosWaveMacHelper with WifiMacHelper and OcbWifiMac
  * Removed AdhocWifiMac dependency, now using WifiMac base class
  * Updated CcaMode1Threshold to CcaEdThreshold
- Fixed header includes:
  * Changed adhoc-wifi-mac.h to wifi-mac.h
  * Updated WAVE header includes
- Updated example program (pagpsr-main.cc) for ns-3.40 API
- Created comprehensive migration documentation (MIGRATION_TO_NS3.40.md)
- Updated README.md with ns-3.40 installation instructions

All three routing protocols (PA-GPSR, GPSR, MM-GPSR) and the location-service module are now fully compatible with ns-3.40.